### PR TITLE
Adapt new API and add object allocation counter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,9 +238,9 @@
       }
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
       "dev": true
     },
     "ajv": {
@@ -873,6 +873,17 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "cache-base": {
@@ -1257,6 +1268,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -1505,6 +1527,12 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -1599,6 +1627,15 @@
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -1892,6 +1929,34 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1921,6 +1986,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "etag": {
@@ -2173,6 +2244,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "faye-websocket": {
@@ -2926,6 +3003,17 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "function-bind": {
@@ -4007,6 +4095,16 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4359,6 +4457,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -4461,6 +4570,15 @@
         "which": "1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -4805,6 +4923,20 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "original": {
@@ -5207,6 +5339,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
       "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "pretty-error": {
@@ -5686,9 +5824,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -6726,6 +6864,17 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "source-map": {
@@ -6885,6 +7034,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.18",
@@ -7210,6 +7368,12 @@
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -7572,6 +7736,12 @@
           }
         }
       }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 		"url": "https://github.com/freezy/vpweb"
 	},
 	"scripts": {
-		"start:dev": "webpack-dev-server --inline --progress"
+		"start": "npm run serve",
+		"serve": "webpack-dev-server --inline --progress",
+		"build": "rimraf dist && webpack --bail --progress --profile --json > stats.json"
 	},
 	"keywords": [
 		"vpinball",
@@ -23,12 +25,16 @@
 		"three": "0.108.0"
 	},
 	"devDependencies": {
+		"acorn": "^7.0.0",
 		"autoprefixer": "9.6.1",
 		"copy-webpack-plugin": "5.0.4",
 		"css-loader": "3.2.0",
-		"html-webpack-plugin": "^3.2.0",
-		"node-sass": "^4.12.0",
-		"postcss-loader": "^3.0.0",
+		"escodegen": "1.12.0",
+		"estraverse": "4.3.0",
+		"html-webpack-plugin": "3.2.0",
+		"node-sass": "4.12.0",
+		"postcss-loader": "3.0.0",
+		"rimraf": "3.0.0",
 		"sass-loader": "7.3.1",
 		"style-loader": "1.0.0",
 		"webpack": "4.39.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,13 @@
 import './index.sass';
+
+// class A {
+// 	constructor() {
+// 		console.log('A created!');
+// 	}
+// }
+//
+// const a = new A();
+
 import { Controller } from './controller';
 import { FileCache } from './file-cache';
 import { Loader } from './loader';
@@ -21,5 +30,3 @@ cache.init()
 			window.vpw.controller = new Controller(renderer);
 		}
 	});
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,5 @@
 import './index.sass';
 
-// class A {
-// 	constructor() {
-// 		console.log('A created!');
-// 	}
-// }
-//
-// const a = new A();
-
 import { Controller } from './controller';
 import { FileCache } from './file-cache';
 import { Loader } from './loader';

--- a/src/physics.js
+++ b/src/physics.js
@@ -100,7 +100,9 @@ export class Physics {
 
 	update() {
 		this._player.updatePhysics();
-		this._updateState(this._player.popStates())
+		const states = this._player.popStates();
+		this._updateState(states);
+		states.release();
 	}
 
 	leftFlipperKeyDown() {
@@ -146,11 +148,11 @@ export class Physics {
 	 */
 	_updateState(states) {
 
-		if (this.ballName && !Object.keys(states).includes(this.ballName)) {
+		if (this.ballName && !states.keys.includes(this.ballName)) {
 			console.warn('Ball did not move!');
 		}
-		for (const name of Object.keys(states)) {
-			const state = states[name].newState;
+		for (const name of states.keys) {
+			const state = states.getState(name).newState;
 			if (!this.sceneItems[state.getName()]) {
 				//console.warn('No scene item called %s found!', state.getName(), states);
 				break;
@@ -167,7 +169,7 @@ export class Physics {
 			}
 			const tableItem = this.tableItems[state.getName()];
 			const sceneItem = this.sceneItems[state.getName()];
-			tableItem.applyState(sceneItem, this.table, this._player, states[name].oldState);
+			tableItem.applyState(sceneItem, this.table, this._player, states.getState(name).oldState);
 		}
 	}
 }

--- a/src/physics.js
+++ b/src/physics.js
@@ -164,7 +164,7 @@ export class Physics {
 
 			if (this.keyDownTime) {
 				const lat = performance.now() - this.keyDownTime;
-				console.debug('[Latency] = %sms', Math.round(lat * 1000) / 1000);
+				//console.debug('[Latency] = %sms', Math.round(lat * 1000) / 1000);
 				this.keyDownTime = undefined;
 			}
 			const tableItem = this.tableItems[state.getName()];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const { resolve } = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = () => {
@@ -11,10 +12,14 @@ module.exports = () => {
 			new HtmlWebpackPlugin({
 				template: 'src/index.html',
 				minify: true,
-			})
+			}),
+			new webpack.ProvidePlugin({
+				__alloc__: resolve('./webpack/alloc-log-collector'),
+			}),
 		],
 		module: {
 			rules: [
+				{ test: /\.js$/, use: [{ loader: resolve('./webpack/alloc-log-loader'), }]},
 				{
 					test: /\.(scss|sass)$/,
 					use: [{
@@ -41,7 +46,8 @@ module.exports = () => {
 			filename: '[name].bundle-[chunkhash].js',
 			hashFunction: 'sha256',
 			hashDigest: 'hex',
-			hashDigestLength: 12,
+			hashDigestLength: 12
 		},
+		devtool: 'source-map'
 	};
 };

--- a/webpack/alloc-log-collector.js
+++ b/webpack/alloc-log-collector.js
@@ -24,7 +24,7 @@ function logAllocations() {
 		const total = Object.values(allocations[className]).reduce((prev, curr) => prev + curr, 0);
 		console.debug('[%s] %s', className, total);
 		for (const location of Object.keys(allocations[className])) {
-			console.debug('   %d %s', allocations[className][location], location);
+			console.debug('   %d @ %s', allocations[className][location], location);
 			n += allocations[className][location] ;
 		}
 	}

--- a/webpack/alloc-log-collector.js
+++ b/webpack/alloc-log-collector.js
@@ -1,0 +1,50 @@
+let allocations = {};
+let interval = 0;
+
+export function instantiate(instance, location) {
+	if (!interval) {
+		return instance;
+	}
+	const className = instance.constructor.name;
+
+	if (!allocations[className]) {
+		allocations[className] = {};
+	}
+	if (!allocations[className][location]) {
+		allocations[className][location] = 0;
+	}
+	allocations[className][location]++;
+
+	return instance;
+}
+
+function logAllocations() {
+	let n = 0;
+	for (const className of Object.keys(allocations)) {
+		const total = Object.values(allocations[className]).reduce((prev, curr) => prev + curr, 0);
+		console.debug('[%s] %s', className, total);
+		for (const location of Object.keys(allocations[className])) {
+			console.debug('   %d %s', allocations[className][location], location);
+			n += allocations[className][location] ;
+		}
+	}
+	console.debug('----- %s instantiations total. ---------------------------------------------------------------------------------', n);
+	allocations = {};
+}
+
+const glob = typeof window !== 'undefined' ? window : global;
+glob.startAllocationLogging = function(time) {
+	if (interval) {
+		console.warn('Already logging!');
+		return;
+	}
+	time = time || 10000;
+	console.debug('Started logging every %ss.', time / 1000);
+	interval = setInterval(logAllocations, time);
+};
+
+glob.stopAllocationLogging = function() {
+	clearInterval(interval);
+	interval = 0;
+	console.debug('Stopped logging.');
+};

--- a/webpack/alloc-log-loader.js
+++ b/webpack/alloc-log-loader.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path');
+const { resolve, relative } = require('path');
 const esprima = require('esprima');
 const acorn = require('acorn');
 const traverse = require('estraverse');
@@ -9,11 +9,7 @@ module.exports = function(source, map, meta) {
 		this.cacheable();
 	}
 
-	const root = resolve(__dirname, '..');
-	let filePath = this.resourcePath.replace(root, '').replace(/\\/g, '/');
-	if (filePath.startsWith('/')) {
-		filePath = filePath.substr(1);
-	}
+	const filePath = 'webpack:///' + relative(resolve(__dirname, '..'), this.resourcePath).replace(/\\/g, '/');
 	try {
 		const ast = acorn.parse(source,  { sourceType: 'module' });
 		const modifiedAst = traverse.replace(ast, {
@@ -22,7 +18,7 @@ module.exports = function(source, map, meta) {
 					return node;
 				}
 
-				const key = `${filePath}#${findLine(source, node.start)}`;
+				const key = `${filePath}:${findLine(source, node.start)}`;
 				return {
 					type: 'CallExpression',
 					callee: {

--- a/webpack/alloc-log-loader.js
+++ b/webpack/alloc-log-loader.js
@@ -14,7 +14,10 @@ module.exports = function(source, map, meta) {
 		const ast = acorn.parse(source,  { sourceType: 'module' });
 		const modifiedAst = traverse.replace(ast, {
 			leave: node => {
-				if (node.type !== 'NewExpression') {
+				if (filePath.includes('alloc-log-collector')) {
+					return node;
+				}
+				if (node.type !== 'NewExpression' && node.type !== 'ObjectExpression' && node.type !== 'ArrayExpression') {
 					return node;
 				}
 

--- a/webpack/alloc-log-loader.js
+++ b/webpack/alloc-log-loader.js
@@ -1,0 +1,77 @@
+const { resolve } = require('path');
+const esprima = require('esprima');
+const acorn = require('acorn');
+const traverse = require('estraverse');
+const codegen = require('escodegen');
+
+module.exports = function(source, map, meta) {
+	if (this.cacheable) {
+		this.cacheable();
+	}
+
+	const root = resolve(__dirname, '..');
+	let filePath = this.resourcePath.replace(root, '').replace(/\\/g, '/');
+	if (filePath.startsWith('/')) {
+		filePath = filePath.substr(1);
+	}
+	try {
+		const ast = acorn.parse(source,  { sourceType: 'module' });
+		const modifiedAst = traverse.replace(ast, {
+			leave: node => {
+				if (node.type !== 'NewExpression') {
+					return node;
+				}
+
+				const key = `${filePath}#${findLine(source, node.start)}`;
+				return {
+					type: 'CallExpression',
+					callee: {
+						type: 'MemberExpression',
+						object: {
+							type: 'Identifier',
+							name: '__alloc__'
+						},
+						property: {
+							type: 'Identifier',
+							name: 'instantiate'
+						},
+						computed: false
+					},
+					arguments: [
+						node,
+						{
+							type: 'Literal',
+							value: key,
+							raw: `'${key}'`,
+						}
+					]
+				};
+			}
+		});
+		const result = codegen.generate(modifiedAst);
+
+		if (this.sourceMap === false) {
+			return this.callback(null, result);
+		}
+
+		this.callback(null, result);
+
+	} catch (err) {
+		console.error(source);
+		console.error('----------- ERROR:', err);
+		return this.callback(err);
+	}
+};
+
+function findLine(src, charPos) {
+	let linePos = 0;
+	for (let i = 0; i < charPos; i++) {
+		if (src[i] === '\r' || src[i] === '\n') {
+			linePos++;
+		}
+		if (src[i + 1] === '\n') {
+			i++;
+		}
+	}
+	return linePos;
+}


### PR DESCRIPTION
When popping states, the returned states are recycled and are now freed once used.

Additionally, this implements a object allocation counter. It's a Webpack loader that wraps object allocations in a function that updates a counter where the allocation happened. Three types are logged:

1. Class instantiation, e.g. `const x = new MyClass()`
2. Object instantiation, e.g. `const x = { prop: 'value' }`
3. Array instantiation, e.g. `const x = [ 1, 2, 3 ]`

A global function `startAllocationLogging()` is defined that can be used to start periodically measuring:

![image](https://user-images.githubusercontent.com/70426/64480111-02106400-d1c2-11e9-9697-f03a2b52bcaa.png)

This allows rapidly identifying where performance can be improved by recycling objects or use other constructs to pass data than instantiating objects.