### PR TITLE
Disable ES Module syntax in file-loader

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -94,9 +94,15 @@ module.exports = opts => {
 					],
 				},
 				{
-					test: /\.(eot|woff|woff2|ttf|otf|png|jpg|swf|hdr|exr|vpx)$/,
-					use: { loader: 'file-loader', options: {name: '[path][name]-[sha256:hash:base58:8].[ext]'} },
-				}, {
+					test: /\.(eot|woff2?|ttf|otf|png|jpe?g|swf|hdr|exr|vpx)$/i,
+					use: {
+						loader: 'file-loader',
+						options: {
+							name: '[path][name]-[sha256:hash:base58:8].[ext]',
+							esModule: false
+						} },
+				},
+				{
 					test: /\.ejs$/,
 					use: 'ejs-loader',
 				},


### PR DESCRIPTION
The behavior of `file-loader` changed in a recent update (merged in #47), resulting in `[object Module]` being returned instead of the path to an asset, like in the banner image:
`<meta name="og:image" content="[object Module]">`

Taking a tip from this [issue](https://github.com/webpack-contrib/file-loader/issues/353), disabling ES module syntax fixes the problem.

Minor regex cleanup too.


