### PR TITLE
Add host flag for webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"scripts": {
 		"start": "npm run serve",
-		"serve": "webpack-dev-server --config webpack/webpack.dev.js --inline --progress",
+		"serve": "webpack-dev-server --host 0.0.0.0 --config webpack/webpack.dev.js --inline --progress",
 		"serve:prod": "npm run build && http-server ./dist -a 127.0.0.1",
 		"build": "rimraf dist && webpack --config webpack/webpack.prod.js --bail --progress --profile --json > stats.json",
 		"build:analyze": "rimraf dist && webpack --config webpack/webpack.analyze.js --bail --progress --profile --json > stats.json",


### PR DESCRIPTION
I had problems with port forwarding vpweb from a vagrant guest system. Making the dev server publicly available resolved the port forwarding issue.

But - I realize this may be problematic. Is there a way to have vagrant port forwarding work without changing everyone's dev server to be public?

**Before:**
```
sudo netstat -ltpn | grep 8080
tcp        0      127 0.0.0.1:8080            0.0.0.0:*               LISTEN      3043/node
```
**After:**
```
sudo netstat -ltpn | grep 8080
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      3043/node
```

[related SO](https://stackoverflow.com/questions/33272967/how-to-make-the-webpack-dev-server-run-on-port-80-and-on-0-0-0-0-to-make-it-publ)