### PR TITLE
Fix `Uncaught TypeError` occurring on Firefox

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -66,7 +66,7 @@ export class Loader {
 	}
 
 	downloadTable(event) {
-		const url = event.toElement.getAttribute('data-table');
+		const url = event.target.getAttribute('data-table');
 		fetch(url)
 			.then(res => res.blob())
 			.then(blob => this.cache.save(blob))


### PR DESCRIPTION
In `loader.js`, the expression:

> `event.toElement`

causes the following error message on Firefox when the user invokes any action in the UI:

```
Uncaught TypeError: can't access property "getAttribute", event.toElement is undefined
    downloadTable loader.js:69
    onclick (index):1
```

This is caused by the usage of a browser-specific property, `toElement`, which [appears to exist only on IE and Chrome](https://stackoverflow.com/q/8600174).

Fix this by using [`event.target`](https://developer.mozilla.org/en-US/docs/Web/API/Event/target) instead, the official property that all browsers recognize.
